### PR TITLE
Simple adaptive poll algorithm choosing poll method based on IOPS

### DIFF
--- a/Makefile.fio
+++ b/Makefile.fio
@@ -15,7 +15,7 @@ include $(RTE_SDK)/mk/rte.vars.mk
 CFLAGS += -I$(FIO_SOURCE_DIR)
 CFLAGS += -O3
 CFLAGS += -Wall -Werror
-CFLAGS += -D_GNU_SOURCE -DSLEEPY_POLL=0
+CFLAGS += -D_GNU_SOURCE
 #CFLAGS += -ggdb3 -O0
 LDFLAGS += -rpath=$(CURDIR)/lib
 LDLIBS += --whole-archive -lrte_eal -lrte_ring --no-whole-archive -lnuma

--- a/common.h
+++ b/common.h
@@ -40,9 +40,4 @@
 #define	debug(...)
 #endif
 
-// decides if we sleep instead of using poll + eventfd
-#ifndef SLEEPY_POLL
-#define	SLEEPY_POLL	0
-#endif
-
 #endif   // _VIRTIO_COMMON_H

--- a/test.c
+++ b/test.c
@@ -31,6 +31,7 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <assert.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -63,14 +64,18 @@ ssize_t wait_for_io(dev_handle_t dev, uintptr_t io_num)
     struct timespec ts1, ts2;
     async_io_desc_t *io_desc;
     int64_t us;
+    int n;
 
     clock_gettime(CLOCK_REALTIME, &ts1);
 
-    io_desc = virtio_get_completed(dev, 1000);
-    if (io_desc == NULL) {
+    n = virtio_completed(dev, 1, 1000);
+    if (n == 0) {
         fprintf(stderr, "Timed out waiting for IO\n");
         return (-1);
     }
+    io_desc = virtio_get_completed(dev);
+    assert(io_desc != NULL);
+
     if (io_desc->user_ctx != (void *)io_num) {
         fprintf(stderr, "Unexpected IO completed\n");
         return (-1);

--- a/virtio_dev.h
+++ b/virtio_dev.h
@@ -75,6 +75,6 @@ int write_virtio_dev(dev_handle_t hdl, void *buf, size_t blk_offset, size_t nblk
 // async API
 int virtio_submit(struct virtio_dev *dev, async_io_desc_t *io_desc);
 int virtio_completed(struct virtio_dev *dev, int mincount, int timeout);
-async_io_desc_t *virtio_get_completed(struct virtio_dev *dev, int timeout);
+async_io_desc_t *virtio_get_completed(struct virtio_dev *dev);
 
 #endif

--- a/vring.c
+++ b/vring.c
@@ -92,9 +92,6 @@ vring_create(void)
 		free(vring);
 		return (NULL);
 	}
-#if (SLEEPY_POLL != 0)
-	vring->avail->flags = VRING_AVAIL_F_NO_INTERRUPT;
-#endif
 
 	return (vring);
 }


### PR DESCRIPTION
This is a bit experimental feature which tries to change polling mechanism based on current number of IOPS. It has been tested in VM and on real HW. For artificial workload generated by benchmarks the behaviour is reasonable, however I'm not sure how it would perform with more real workloads. Consider this as a first attempt to tackle this problem.