### PR TITLE
Add core_mask option to FIO. This prevents FIO from running on CPU 0

### DIFF
--- a/fio_plugin.c
+++ b/fio_plugin.c
@@ -41,6 +41,7 @@
 struct virtio_fio_options {
 	void *padding;
 	unsigned mem_mb;
+	unsigned core_mask;
 };
 
 static dev_handle_t g_hdl = NULL;
@@ -64,6 +65,14 @@ virtio_fio_setup(struct thread_data *td)
 {
 	struct virtio_fio_options *eo = (struct virtio_fio_options *)td->eo;
 	int mem_mb = (eo->mem_mb == 0) ? 1024 : eo->mem_mb;
+
+	/*
+	 *  FIO has a cpumask field as well, however this is currently
+	 *  not available (#if 0-ed) in the thread_data structure
+	 *
+	 */
+
+	int core_mask = (eo->core_mask == 0) ? 1 : eo->core_mask;
 	unsigned int i;
 	struct fio_file *f;
 	const char *filename = NULL;
@@ -74,7 +83,7 @@ virtio_fio_setup(struct thread_data *td)
 	}
 
 	if (!g_virtio_env_initialized) {
-		if (libvirtio_dev_init(mem_mb) != 0) {
+		if (libvirtio_dev_init(mem_mb, core_mask) != 0) {
 			fprintf(stderr, "Failed to initialize\n");
 			return -1;
 		}
@@ -272,6 +281,15 @@ static struct fio_option options[] = {
 		.type		= FIO_OPT_INT,
 		.off1		= offsetof(struct virtio_fio_options, mem_mb),
 		.help 		= "Memory to allocate for virtio from huge pages in MB",
+		.category	= FIO_OPT_C_ENGINE,
+		.group		= FIO_OPT_G_INVALID,
+	},
+	{
+		.name		= "core_mask",
+		.lname		= "core mask",
+		.type		= FIO_OPT_INT,
+		.off1		= offsetof(struct virtio_fio_options, core_mask),
+		.help 		= "core mask",
 		.category	= FIO_OPT_C_ENGINE,
 		.group		= FIO_OPT_G_INVALID,
 	},

--- a/shm.c
+++ b/shm.c
@@ -131,15 +131,17 @@ error:
  * functionality which is not needed.
  */
 int
-init_shared_mem(int mem_mb)
+init_shared_mem(int mem_mb, int mask)
 {
 	char *argv[20];
 	int argc = 0;
 	char mem_opt[20];
+	char core_mask[20];
 	char file_prefix[30];
 
 	snprintf(mem_opt, 20, "-m%d", mem_mb);
 	snprintf(file_prefix, 30, "--file-prefix=pid%d", getpid());
+	snprintf(core_mask, 20, "-c %x", mask);
 
 	argv[argc++] = "vhost";
 	//argv[argc++] = "--log-level=10";
@@ -148,6 +150,7 @@ init_shared_mem(int mem_mb)
 	argv[argc++] = mem_opt;
 	// to avoid conflict between multiple running instances
 	argv[argc++] = file_prefix;
+	argv[argc++] = core_mask;
 	argv[argc] = NULL;
 
 	if (rte_eal_init(argc, argv) < 0) {

--- a/shm.h
+++ b/shm.h
@@ -42,7 +42,7 @@
  *
  * These are essentially wrappers around dpdk's rte_eal calls.
  */
-int init_shared_mem(int mem_mb);
+int init_shared_mem(int mem_mb, int core_mask);
 void *alloc_shared_buf(int size, int alignment);
 void *zalloc_shared_buf(int size, int alignment);
 void free_shared_buf(void *buf);

--- a/virtio_dev.c
+++ b/virtio_dev.c
@@ -91,9 +91,9 @@ struct virtio_dev {
 };
 
 int
-libvirtio_dev_init(int mem_mb)
+libvirtio_dev_init(int mem_mb, int core_mask)
 {
-	return (init_shared_mem(mem_mb));
+	return (init_shared_mem(mem_mb, core_mask));
 }
 
 static int

--- a/virtio_dev.h
+++ b/virtio_dev.h
@@ -63,7 +63,7 @@ typedef struct async_io_desc {
 	ssize_t retval;  // code as would have been normally returned by read/write call
 } async_io_desc_t;
 
-int libvirtio_dev_init(int mem_mb);
+int libvirtio_dev_init(int mem_mb, int core_mask);
 dev_handle_t open_virtio_dev(const char *sock);
 size_t virtio_dev_block_size(dev_handle_t hdl);
 size_t virtio_dev_blocks_num(dev_handle_t hdl);


### PR DESCRIPTION
which is the default core mask for DPDK/SPDK.

Example cmd line:
```
LD_LIBRARY_PATH=/home/gila/vhost-user/build/lib ./fio --ioengine=fio_virtio --thread=1 --group_reporting=1 --direct=1 --verify=0 --time_based=1 --ramp_time=0 --runtime=3600 --iodepth=128 --rw=randrw --bs=512 --hugepage_mem=1024 --core_mask=2 --name=test --numjobs=1 --filename=/tmp/vhost.0
```